### PR TITLE
BRING-17: Implement ComponentAnnotationScanner

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -2,4 +2,3 @@ config.stopBubbling = true
 lombok.anyconstructor.addconstructorproperties = false
 lombok.addLombokGeneratedAnnotation = true
 lombok.experimental.flagUsage = WARNING
-lombok.log.fieldname= LOG

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.23.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.24</version>

--- a/src/main/java/org/blyznytsia/annotation/Component.java
+++ b/src/main/java/org/blyznytsia/annotation/Component.java
@@ -27,4 +27,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Component {
+
+    String value() default "";
 }

--- a/src/test/java/org/blyznytsia/scanner/ComponentAnnotationScannerTest.java
+++ b/src/test/java/org/blyznytsia/scanner/ComponentAnnotationScannerTest.java
@@ -1,0 +1,44 @@
+package org.blyznytsia.scanner;
+
+
+import org.assertj.core.api.Assertions;
+import org.blyznytsia.model.BeanDefinition;
+import org.blyznytsia.scanner.data.TestService1;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+class ComponentAnnotationScannerTest {
+
+    private static final String PACKAGE_NAME = "org.blyznytsia.scanner.data";
+    private static final String SERVICE1_NAME = "anotherNameService";
+    private static final String SERVICE2_NAME = "testService2";
+    private static final int BEAN_DEFINITIONS_SIZE = 2;
+    private static final int SERVICE2_DEPENDENCIES_SIZE = 1;
+    private static final String SERVICE2_DEPENDENCY_NAME = TestService1.class.getName();
+
+    @Test
+    void scan_givenValidPackage_shouldReturnValidBeanDefinitionsList() {
+        final var beanDefinitions =
+                new ComponentAnnotationScanner().scan(PACKAGE_NAME);
+        beanDefinitions.forEach(System.out::println);
+        Assertions.assertThat(checkFullPresence(beanDefinitions, SERVICE2_NAME, SERVICE1_NAME)).isTrue();
+
+        final var service1 = getBeanDefinitionByName(beanDefinitions, SERVICE1_NAME);
+        final var service2 = getBeanDefinitionByName(beanDefinitions, SERVICE2_NAME);
+
+        Assertions.assertThat(beanDefinitions).hasSize(BEAN_DEFINITIONS_SIZE);
+        Assertions.assertThat(service1.getDependsOnBeans()).isEmpty();
+        Assertions.assertThat(service2.getDependsOnBeans()).hasSize(SERVICE2_DEPENDENCIES_SIZE);
+        Assertions.assertThat(service2.getDependsOnBeans().get(0)).isEqualTo(SERVICE2_DEPENDENCY_NAME);
+    }
+
+    private BeanDefinition getBeanDefinitionByName(final List<BeanDefinition> list, final String name) {
+        return list.stream().filter(el -> el.getName().equals(name)).findFirst().orElseThrow();
+    }
+
+    private boolean checkFullPresence(final List<BeanDefinition> list, final String... names) {
+        return Arrays.equals(list.stream().map(BeanDefinition::getName).toArray(), names);
+    }
+}

--- a/src/test/java/org/blyznytsia/scanner/ComponentAnnotationScannerTest.java
+++ b/src/test/java/org/blyznytsia/scanner/ComponentAnnotationScannerTest.java
@@ -1,44 +1,54 @@
 package org.blyznytsia.scanner;
 
 
-import org.assertj.core.api.Assertions;
+import lombok.extern.slf4j.Slf4j;
 import org.blyznytsia.model.BeanDefinition;
 import org.blyznytsia.scanner.data.TestService1;
+import org.blyznytsia.scanner.data.TestService3;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@Slf4j
 class ComponentAnnotationScannerTest {
 
     private static final String PACKAGE_NAME = "org.blyznytsia.scanner.data";
     private static final String SERVICE1_NAME = "anotherNameService";
     private static final String SERVICE2_NAME = "testService2";
-    private static final int BEAN_DEFINITIONS_SIZE = 2;
-    private static final int SERVICE2_DEPENDENCIES_SIZE = 1;
-    private static final String SERVICE2_DEPENDENCY_NAME = TestService1.class.getName();
+    private static final String SERVICE1_DEPENDENCY_NAME = TestService3.class.getName();
+    private static final String[] SERVICE2_DEPENDENCY_NAMES = {TestService1.class.getName(), TestService3.class.getName()};
+    private static final String NPE_MSG = "packageName is marked non-null but is null";
+
+    private final ComponentAnnotationScanner scanner = new ComponentAnnotationScanner();
 
     @Test
     void scan_givenValidPackage_shouldReturnValidBeanDefinitionsList() {
-        final var beanDefinitions =
-                new ComponentAnnotationScanner().scan(PACKAGE_NAME);
-        beanDefinitions.forEach(System.out::println);
-        Assertions.assertThat(checkFullPresence(beanDefinitions, SERVICE2_NAME, SERVICE1_NAME)).isTrue();
+        var beanDefinitions = scanner.scan(PACKAGE_NAME);
+        log.debug("List<BeanDefinitions> [{}]: {}", beanDefinitions.size(), beanDefinitions);
 
-        final var service1 = getBeanDefinitionByName(beanDefinitions, SERVICE1_NAME);
-        final var service2 = getBeanDefinitionByName(beanDefinitions, SERVICE2_NAME);
+        assertThat(beanDefinitions).map(BeanDefinition::getName)
+                .containsOnly(SERVICE2_NAME, SERVICE1_NAME);
 
-        Assertions.assertThat(beanDefinitions).hasSize(BEAN_DEFINITIONS_SIZE);
-        Assertions.assertThat(service1.getDependsOnBeans()).isEmpty();
-        Assertions.assertThat(service2.getDependsOnBeans()).hasSize(SERVICE2_DEPENDENCIES_SIZE);
-        Assertions.assertThat(service2.getDependsOnBeans().get(0)).isEqualTo(SERVICE2_DEPENDENCY_NAME);
+        var service1 = getBeanDefinitionByName(beanDefinitions, SERVICE1_NAME);
+        var service2 = getBeanDefinitionByName(beanDefinitions, SERVICE2_NAME);
+
+        assertThat(service1.getDependsOnBeans())
+                .containsOnly(SERVICE1_DEPENDENCY_NAME);
+        assertThat(service2.getDependsOnBeans())
+                .containsOnly(SERVICE2_DEPENDENCY_NAMES);
     }
 
-    private BeanDefinition getBeanDefinitionByName(final List<BeanDefinition> list, final String name) {
+    @Test
+    void scan_givenNullPackage_shouldThrowNPEWithCertainMsg() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> scanner.scan(null))
+                .withMessage(NPE_MSG);
+    }
+
+    private BeanDefinition getBeanDefinitionByName(List<BeanDefinition> list, String name) {
         return list.stream().filter(el -> el.getName().equals(name)).findFirst().orElseThrow();
-    }
-
-    private boolean checkFullPresence(final List<BeanDefinition> list, final String... names) {
-        return Arrays.equals(list.stream().map(BeanDefinition::getName).toArray(), names);
     }
 }

--- a/src/test/java/org/blyznytsia/scanner/data/TestService1.java
+++ b/src/test/java/org/blyznytsia/scanner/data/TestService1.java
@@ -1,0 +1,11 @@
+package org.blyznytsia.scanner.data;
+
+import org.blyznytsia.annotation.Autowired;
+import org.blyznytsia.annotation.Component;
+
+@Component("anotherNameService")
+public class TestService1 {
+
+    @Autowired
+    private TestService3 service;
+}

--- a/src/test/java/org/blyznytsia/scanner/data/TestService2.java
+++ b/src/test/java/org/blyznytsia/scanner/data/TestService2.java
@@ -1,0 +1,14 @@
+package org.blyznytsia.scanner.data;
+
+import org.blyznytsia.annotation.Autowired;
+import org.blyznytsia.annotation.Component;
+
+@Component
+public class TestService2 {
+
+    @Autowired
+    private TestService1 service1;
+
+    @Autowired
+    private TestService3 service2;
+}

--- a/src/test/java/org/blyznytsia/scanner/data/TestService3.java
+++ b/src/test/java/org/blyznytsia/scanner/data/TestService3.java
@@ -1,0 +1,4 @@
+package org.blyznytsia.scanner.data;
+
+public class TestService3 {
+}


### PR DESCRIPTION
# Why:
It allows us to find the beans to put in the ApplicationContext

# How:
1. Scan provided package
2. Find all classes annotated with **Component** annotation
3. Create **BeanDefinition** based on these classes
4. If the class has fields annotated with **Autowired** annotation, then add dependencies to **BeanDefinition#dependsOnBeans**
5. Return **Collection** of **BeanDefinition**

# Testing:
Test data is taken from **org.blyznytsia.scanner.data** test package

<img width="818" alt="Screenshot 2022-07-21 at 1 50 43 PM" src="https://user-images.githubusercontent.com/20487669/180280827-c2106d9b-4fb4-423d-a2e2-b03b96265d6c.png">