### PR TITLE
Add DependencyValidator to AnnotationApplicationContext

### DIFF
--- a/src/main/java/org/blyznytsia/exception/CircularDependencyException.java
+++ b/src/main/java/org/blyznytsia/exception/CircularDependencyException.java
@@ -1,0 +1,12 @@
+package org.blyznytsia.exception;
+
+/** Exception accrued when between beans exist circular dependency */
+public class CircularDependencyException extends RuntimeException {
+
+  private static final String EXCEPTION_DESCRIPTION =
+      "There is a circular dependency between beans in the application context:\n";
+
+  public CircularDependencyException(String message) {
+    super(EXCEPTION_DESCRIPTION + message);
+  }
+}

--- a/src/main/java/org/blyznytsia/validator/BeanValidator.java
+++ b/src/main/java/org/blyznytsia/validator/BeanValidator.java
@@ -1,0 +1,9 @@
+package org.blyznytsia.validator;
+
+import java.util.List;
+import org.blyznytsia.model.BeanDefinition;
+
+public interface BeanValidator {
+
+  void validate(List<BeanDefinition> beanDefinitions);
+}

--- a/src/main/java/org/blyznytsia/validator/DependencyValidator.java
+++ b/src/main/java/org/blyznytsia/validator/DependencyValidator.java
@@ -1,0 +1,103 @@
+package org.blyznytsia.validator;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.blyznytsia.exception.CircularDependencyException;
+import org.blyznytsia.model.BeanDefinition;
+
+/** Validator that checks beans for circular dependencies */
+public class DependencyValidator implements BeanValidator {
+
+  /** Map of beans. Key is a bean, and value is a list of beans in which the key bean depends. */
+  private Map<String, List<String>> beans;
+
+  public DependencyValidator() {}
+
+  /**
+   * Validate list of bean definitions
+   *
+   * @param beanDefinitions list of bean definitions
+   * @throws CircularDependencyException if circular dependency happens
+   */
+  public void validate(List<BeanDefinition> beanDefinitions) {
+    this.beans =
+        beanDefinitions.stream()
+            .collect(Collectors.toMap(BeanDefinition::getName, BeanDefinition::getDependsOnBeans));
+    validateBeans();
+  }
+
+  /**
+   * Calculate cycles between beans.
+   *
+   * <p>when find cycles then throw {@link CircularDependencyException} with beans
+   */
+  private void validateBeans() {
+    Set<String> visited = new HashSet<>();
+
+    List<String> cycles =
+        beans.keySet().stream()
+            .map(bean -> findCycles(bean, visited, Collections.emptyList()))
+            .filter(cycle -> !cycle.isEmpty())
+            .map(cycle -> String.join("->", cycle))
+            .toList();
+
+    if (!cycles.isEmpty()) {
+      throwException(cycles);
+    }
+  }
+
+  private void throwException(List<String> cycles) {
+    String chainOfCycles = buildChainOfBeanCycles(cycles);
+    throw new CircularDependencyException(chainOfCycles);
+  }
+
+  private String buildChainOfBeanCycles(List<String> cycles) {
+    StringBuilder chainOfCycles = new StringBuilder();
+    for (int i = 0; i < cycles.size(); i++) {
+
+      String cycle = cycles.get(i);
+      chainOfCycles.append(i).append(": ").append(cycle);
+
+      if (i < cycles.size() - 1) {
+        chainOfCycles.append("\n");
+      }
+    }
+    return chainOfCycles.toString();
+  }
+
+  /**
+   * Recursive method to calculate circular dependency
+   *
+   * @param bean is a bean name.
+   * @param visited is a set of beans that is checked and added to collection
+   * @param path is a list of beans that is added to path
+   * @return empty set or {@link CircularDependencyException}
+   */
+  private List<String> findCycles(String bean, Set<String> visited, List<String> path) {
+
+    List<String> newPath = new LinkedList<>(path);
+    newPath.add(bean);
+
+    if (path.contains(bean)) {
+      return newPath;
+    }
+
+    if (visited.contains(bean)) {
+      return Collections.emptyList();
+    }
+
+    visited.add(bean);
+
+    List<String> dependsOnBeans = beans.get(bean);
+
+    return dependsOnBeans.stream()
+        .map(dep -> findCycles(dep, visited, newPath))
+        .flatMap(List::stream)
+        .toList();
+  }
+}

--- a/src/test/java/org/blyznytsia/validator/DependencyValidatorTest.java
+++ b/src/test/java/org/blyznytsia/validator/DependencyValidatorTest.java
@@ -1,0 +1,125 @@
+package org.blyznytsia.validator;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.List;
+import org.blyznytsia.exception.CircularDependencyException;
+import org.blyznytsia.model.BeanDefinition;
+import org.junit.jupiter.api.Test;
+
+class DependencyValidatorTest {
+
+  static final String SERVICE_1 = "service1";
+  static final String SERVICE_2 = "service2";
+  static final String SERVICE_3 = "service3";
+  static final String SERVICE_4 = "service4";
+  static final String SERVICE_5 = "service5";
+  static final String EXCEPTION_MESSAGE =
+      "There is a circular dependency between beans in the application context:\n";
+
+  @Test
+  void validate_shouldThrowExceptionWithMessage() {
+    BeanDefinition bean1 =
+        BeanDefinition.builder()
+            .name(SERVICE_1)
+            .dependsOnBeans(List.of(SERVICE_2))
+            .type(Service1.class)
+            .build();
+
+    BeanDefinition bean2 =
+        BeanDefinition.builder()
+            .name(SERVICE_2)
+            .dependsOnBeans(List.of(SERVICE_1))
+            .type(Service2.class)
+            .build();
+
+    BeanDefinition bean4 =
+        BeanDefinition.builder()
+            .name(SERVICE_4)
+            .dependsOnBeans(List.of(SERVICE_5))
+            .type(Service4.class)
+            .build();
+
+    BeanDefinition bean5 =
+        BeanDefinition.builder()
+            .name(SERVICE_5)
+            .dependsOnBeans(List.of(SERVICE_4))
+            .type(Service5.class)
+            .build();
+
+    List<BeanDefinition> beanDefinitions = List.of(bean1, bean2, bean4, bean5);
+
+    DependencyValidator dependencyValidator = new DependencyValidator();
+
+    assertThatThrownBy(() -> dependencyValidator.validate(beanDefinitions))
+        .isInstanceOf(CircularDependencyException.class)
+        .hasMessage(
+            EXCEPTION_MESSAGE
+                + "0: service5->service4->service5\n"
+                + "1: service2->service1->service2");
+  }
+
+  @Test
+  void validate_shouldThrowExceptionWithMessage2() {
+    BeanDefinition bean1 =
+        BeanDefinition.builder()
+            .name(SERVICE_1)
+            .dependsOnBeans(List.of(SERVICE_2))
+            .type(Service1.class)
+            .build();
+
+    BeanDefinition bean2 =
+        BeanDefinition.builder()
+            .name(SERVICE_2)
+            .dependsOnBeans(List.of(SERVICE_3))
+            .type(Service2.class)
+            .build();
+
+    BeanDefinition bean3 =
+        BeanDefinition.builder()
+            .name(SERVICE_3)
+            .dependsOnBeans(List.of(SERVICE_1))
+            .type(Service3.class)
+            .build();
+
+    List<BeanDefinition> beanDefinitions = List.of(bean1, bean2, bean3);
+
+    DependencyValidator dependencyValidator = new DependencyValidator();
+
+    assertThatThrownBy(() -> dependencyValidator.validate(beanDefinitions))
+        .isInstanceOf(CircularDependencyException.class)
+        .hasMessage(EXCEPTION_MESSAGE + "0: service2->service3->service1->service2");
+  }
+
+  @Test
+  void validate_validationPassed_noExceptionThrow() {
+
+    BeanDefinition beanOne =
+        BeanDefinition.builder()
+            .name(SERVICE_1)
+            .dependsOnBeans(Arrays.asList(SERVICE_2, SERVICE_3))
+            .type(Service1.class)
+            .build();
+
+    BeanDefinition beanTwo =
+        BeanDefinition.builder()
+            .name(SERVICE_2)
+            .dependsOnBeans(List.of(SERVICE_3))
+            .type(Service2.class)
+            .build();
+
+    BeanDefinition beanThree =
+        BeanDefinition.builder()
+            .name(SERVICE_3)
+            .dependsOnBeans(List.of())
+            .type(Service3.class)
+            .build();
+
+    List<BeanDefinition> beanDefinitions = List.of(beanOne, beanTwo, beanThree);
+
+    DependencyValidator dependencyValidator = new DependencyValidator();
+
+    dependencyValidator.validate(beanDefinitions);
+  }
+}

--- a/src/test/java/org/blyznytsia/validator/Service1.java
+++ b/src/test/java/org/blyznytsia/validator/Service1.java
@@ -1,0 +1,3 @@
+package org.blyznytsia.validator;
+
+public class Service1 {}

--- a/src/test/java/org/blyznytsia/validator/Service2.java
+++ b/src/test/java/org/blyznytsia/validator/Service2.java
@@ -1,0 +1,3 @@
+package org.blyznytsia.validator;
+
+public class Service2 {}

--- a/src/test/java/org/blyznytsia/validator/Service3.java
+++ b/src/test/java/org/blyznytsia/validator/Service3.java
@@ -1,0 +1,3 @@
+package org.blyznytsia.validator;
+
+public class Service3 {}

--- a/src/test/java/org/blyznytsia/validator/Service4.java
+++ b/src/test/java/org/blyznytsia/validator/Service4.java
@@ -1,0 +1,3 @@
+package org.blyznytsia.validator;
+
+public class Service4 {}

--- a/src/test/java/org/blyznytsia/validator/Service5.java
+++ b/src/test/java/org/blyznytsia/validator/Service5.java
@@ -1,0 +1,3 @@
+package org.blyznytsia.validator;
+
+public class Service5 {}


### PR DESCRIPTION
# Why:

To resolve circular dependency problem

# How:

Find circular dependency between bean definitions and throw exceptions

# Testing:

Cover DependencyValidator by tests 